### PR TITLE
Node: Latest LTS Version: 20.9.0

### DIFF
--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -170,8 +170,8 @@ quarkus.quinoa.ui-dir=../horreum-web
 quarkus.quinoa.package-manager-install=true
 quarkus.quinoa.package-manager-command.install=install
 quarkus.quinoa.package-manager-install.install-dir=../horreum-web/node
-quarkus.quinoa.package-manager-install.node-version=18.18.2
-quarkus.quinoa.package-manager-install.npm-version=10.2.1
+quarkus.quinoa.package-manager-install.node-version=20.9.0
+quarkus.quinoa.package-manager-install.npm-version=10.1.0
 quarkus.quinoa.ignored-path-prefixes=/api/,/q/
 
 quarkus.qute.suffixes=qute.html,qute.txt,html,txt,qute.md,md


### PR DESCRIPTION
let's try latest LTS node version in horreum I have downgrade npm version because on the top of the website they say this version include npm 10.1.0 check this-https://nodejs.org/en/download